### PR TITLE
Linux support

### DIFF
--- a/git-chglog.rb
+++ b/git-chglog.rb
@@ -2,11 +2,16 @@ class GitChglog < Formula
   desc "CHANGELOG generator implemented in Go"
   homepage "https://github.com/git-chglog/git-chglog"
   version "0.9.1"
-  url "#{homepage}/releases/download/#{version}/git-chglog_darwin_amd64"
-  sha256 "2023d82b5b505cf8ac4db20f096f439650554e80eb509fe080f5e81b6b477d3c"
+  if OS.mac?
+    url "#{homepage}/releases/download/#{version}/git-chglog_darwin_amd64"
+    sha256 "2023d82b5b505cf8ac4db20f096f439650554e80eb509fe080f5e81b6b477d3c"
+  else
+    url "#{homepage}/releases/download/#{version}/git-chglog_linux_amd64"
+    sha256 "dca7d683a45cf4f0a871735d9981de4e787ef86b82282e8adc813b8738d2c531"
+  end
 
   def install
-    mv "git-chglog_darwin_amd64", "git-chglog"
+    mv OS.mac? ? "git-chglog_darwin_amd64" : "git-chglog_linux_amd64", "git-chglog"
     bin.install "git-chglog"
   end
 

--- a/git-chglog.rb
+++ b/git-chglog.rb
@@ -1,17 +1,16 @@
-require "formula"
-
-REPOSITORY_URL='https://github.com/git-chglog/git-chglog'
-HOMEBREW_GIT_VERSION='0.9.1'
-
 class GitChglog < Formula
-  homepage "#{REPOSITORY_URL}"
-  url "#{REPOSITORY_URL}/releases/download/#{HOMEBREW_GIT_VERSION}/git-chglog_darwin_amd64"
+  desc "CHANGELOG generator implemented in Go"
+  homepage "https://github.com/git-chglog/git-chglog"
+  version "0.9.1"
+  url "#{homepage}/releases/download/#{version}/git-chglog_darwin_amd64"
   sha256 "2023d82b5b505cf8ac4db20f096f439650554e80eb509fe080f5e81b6b477d3c"
-  head "#{REPOSITORY_URL}.git"
-  version "#{HOMEBREW_GIT_VERSION}"
 
   def install
-    system "mv", "git-chglog_darwin_amd64", "git-chglog"
+    mv "git-chglog_darwin_amd64", "git-chglog"
     bin.install "git-chglog"
+  end
+
+  test do
+    system "#{bin}/git-chglog", "--help"
   end
 end

--- a/sha256.sh
+++ b/sha256.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
-REPOSITORY=`grep "REPOSITORY_URL=" git-chglog.rb | sed -E "s/.*'(.+)'$/\1/"`
-VERSION=`grep "GIT_VERSION=" git-chglog.rb | sed -E "s/.*'(.+)'$/\1/"`
+REPOSITORY=`grep "homepage" git-chglog.rb | head -1 | sed -E 's/.*"(.+)"$/\1/'`
+VERSION=`grep "version" git-chglog.rb | head -1 | sed -E 's/.*"(.+)"$/\1/'`
 
-curl -L -O $REPOSITORY/releases/download/$VERSION/git-chglog_darwin_amd64 > /dev/null
+curl -L -O $REPOSITORY/releases/download/$VERSION/git-chglog_darwin_amd64 >/dev/null
+curl -L -O $REPOSITORY/releases/download/$VERSION/git-chglog_linux_amd64 >/dev/null
 openssl dgst -sha256 git-chglog_darwin_amd64
-rm -rf git-chglog_darwin_amd64
+openssl dgst -sha256 git-chglog_linux_amd64
+rm -f git-chglog_darwin_amd64 git-chglog_linux_amd64


### PR DESCRIPTION
I am a [Linuxbrew](https://docs.brew.sh/Homebrew-on-Linux) user (on WSL), so it would be nice if this formula could also work on Linux, which is the aim of this PR.

The first commit is rather for a cleanup; there were 12 errors for `brew audit --strict ./git-chglog.rb`:
```
  * C: 3: col 16: Freeze mutable objects assigned to constants.
  * C: 3: col 16: Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
  * C: 4: col 22: Freeze mutable objects assigned to constants.
  * C: 4: col 22: Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
  * C: 6: col 1: Formula should have a desc (Description).
  * C: 6: col 1: A `test do` test block should be added
  * C: 7: col 3: Formula should have a homepage.
  * C: 7: col 12: Prefer `to_s` over string interpolation.
  * C: 11: col 3: `version` (line 11) should be put before `sha256` (line 9)
  * C: 11: col 11: Prefer `to_s` over string interpolation.
  * C: 14: col 13: Use the `mv` Ruby method instead of `system "mv", "git-chglog_darwin_amd64", "git-chglog"`
  * `require "formula"` is now unnecessary
Error: 12 problems in 1 formula detected
```

The changes include:
- `desc` and `test do ...` are added.
- `url` is defined by using `#{homepage}` and  `#{version}` instead of using extra constants `REPOSITORY_URL` and `HOMEBREW_GIT_VERSION`. (But this requires `version` before `url`. This leads to an audit error, but it disappears after the second commit; maybe the linter does not recognize it.)
- `head` is removed because `brew install --HEAD git-chglog` did not work correctly (should build it from the `HEAD` revision). If you need `head`, probably it can be written as
```ruby

  head "#{homepage}.git"

  def install
    if build.head?
       ...
    else
       ...
    end
  end
```
but I leave it because I am not familiar with Go build tools.

The second commit is actually to add Linuxbrew support (I assume that people use `amd64`).

And, the third one is to fix `sha256.sh` for the above changes.
